### PR TITLE
Initial reports are listed on dashboard and wired up

### DIFF
--- a/lib/FOEGCL/Membership.pm
+++ b/lib/FOEGCL/Membership.pm
@@ -29,6 +29,16 @@ sub startup {
 
     my $logged_in = $r->under('/')->to('login#logged_in');
     $logged_in->get('/dashboard')->to('dashboard#dashboard');
+
+    _set_up_report_routes($logged_in);
+}
+
+sub _set_up_report_routes($logged_in) {
+    my $report = $logged_in->under('/report');
+    $report->get('contributing-friends')->to('report#contributing_friends')
+        ->name('contributing_friends_report');
+    $report->get('current-membership')->to('report#current_membership')
+        ->name('current_membership_report');
 }
 
 1;

--- a/lib/FOEGCL/Membership/Controller/Report.pm
+++ b/lib/FOEGCL/Membership/Controller/Report.pm
@@ -1,0 +1,36 @@
+package FOEGCL::Membership::Controller::Report;
+
+use FOEGCL::Membership::Moose::Mojo;
+extends 'Mojolicious::Controller';
+
+use FOEGCL::Membership::Report::ContributingFriends ();
+use FOEGCL::Membership::Report::Membership          ();
+use Mojo::Asset::Memory                             ();
+
+sub current_membership ($self) {
+    my $report = FOEGCL::Membership::Report::Membership->new;
+
+    $self->_render_pdf_asset(
+        $report->basename,
+        Mojo::Asset::Memory->new->add_chunk( $report->stringify ),
+    );
+}
+
+sub contributing_friends ($self) {
+    my $report = FOEGCL::Membership::Report::ContributingFriends->new;
+
+    $self->_render_pdf_asset(
+        $report->basename,
+        Mojo::Asset::Memory->new->add_chunk( $report->stringify ),
+    );
+}
+
+sub _render_pdf_asset ( $self, $basename, $asset ) {
+    my $clean_basename = $basename =~ s/"//gr;
+    $self->res->headers->content_type('application/pdf');
+    $self->res->headers->content_disposition(
+        qq{attachment; filename="$clean_basename"});
+    $self->reply->asset($asset);
+}
+
+1;

--- a/lib/FOEGCL/Membership/Report/ContributingFriends.pm
+++ b/lib/FOEGCL/Membership/Report/ContributingFriends.pm
@@ -4,7 +4,7 @@ package FOEGCL::Membership::Report::ContributingFriends;
 
 use FOEGCL::Membership::Moose;
 
-use FOEGCL::Membership::Report::PDFReportCreator;
+use FOEGCL::Membership::Report::PDFReportCreator ();
 use POSIX 'strftime';
 
 has _pdf_report_creator => (

--- a/lib/FOEGCL/Membership/Report/ContributingFriends.pm
+++ b/lib/FOEGCL/Membership/Report/ContributingFriends.pm
@@ -12,8 +12,9 @@ has _pdf_report_creator => (
     isa     => 'FOEGCL::Membership::Report::PDFReportCreator',
     lazy    => 1,
     builder => '_build_pdf_report_creator',
-    handles => [qw( save saveas stringify )],
+    handles => [qw( basename save saveas stringify )],
 );
+
 with 'FOEGCL::Membership::Role::UsesWebAppDatabase';
 
 sub _build_pdf_report_creator ( $self, @ ) {

--- a/lib/FOEGCL/Membership/Report/Membership.pm
+++ b/lib/FOEGCL/Membership/Report/Membership.pm
@@ -4,8 +4,8 @@ package FOEGCL::Membership::Report::Membership;
 
 use FOEGCL::Membership::Moose;
 
+use FOEGCL::Membership::Report::PDFReportCreator ();
 use POSIX 'strftime';
-use FOEGCL::Membership::Report::PDFReportCreator;
 
 has _pdf_report_creator => (
     is      => 'ro',

--- a/lib/FOEGCL/Membership/Report/Membership.pm
+++ b/lib/FOEGCL/Membership/Report/Membership.pm
@@ -12,7 +12,7 @@ has _pdf_report_creator => (
     isa     => 'FOEGCL::Membership::Report::PDFReportCreator',
     lazy    => 1,
     builder => '_build_pdf_report_creator',
-    handles => [qw( save saveas stringify )],
+    handles => [qw( basename save saveas stringify )],
 );
 
 with 'FOEGCL::Membership::Role::UsesWebAppDatabase';

--- a/lib/FOEGCL/Membership/Report/PDFReportCreator.pm
+++ b/lib/FOEGCL/Membership/Report/PDFReportCreator.pm
@@ -17,6 +17,13 @@ has name => (
     required => 1,
 );
 
+has basename => (
+    is      => 'ro',
+    isa     => NonEmptySimpleStr,
+    lazy    => 1,
+    builder => '_build_basename',
+);
+
 {
     use Moose::Util::TypeConstraints 'enum';
 
@@ -88,6 +95,14 @@ has _pdf_report_writer => (
     handles => [qw( save saveas stringify )],
 );
 
+sub _build_basename ( $self, @ ) {
+    sprintf(
+        '%s %s',
+        $self->name,
+        DateTime->now->strftime('%Y%m%d %H%M%S.pdf')
+    );
+}
+
 sub _build_data_field_settings_with_defaults ( $self, @ ) {
     my %defaults = (
         align           => 'left',
@@ -105,7 +120,7 @@ sub _build_pdf_report_writer ( $self, @ ) {
     my $pdf_report_writer = PDF::ReportWriter->new(
         {
             destination =>
-                Path::Tiny->cwd->child( $self->_report_basename )->stringify,
+                Path::Tiny->cwd->child( $self->basename )->stringify,
             paper             => 'Letter',
             orientation       => $self->orientation,
             font_list         => [qw( Times )],
@@ -138,10 +153,6 @@ sub _build_pdf_report_writer ( $self, @ ) {
     );
 
     return $pdf_report_writer;
-}
-
-sub _report_basename ( $self ) {
-    return $self->name . q{ } . DateTime->now->strftime('%Y%m%d %H%M%S.pdf');
 }
 
 sub _alternate_data_row_bgcolor ( $value, $row, $options ) {

--- a/lib/FOEGCL/Membership/Report/PDFReportCreator.pm
+++ b/lib/FOEGCL/Membership/Report/PDFReportCreator.pm
@@ -96,7 +96,9 @@ sub _build_data_field_settings_with_defaults ( $self, @ ) {
         background_func => \&_alternate_data_row_bgcolor,
     );
 
-    [ %defaults, map { $_->%* } $self->data_field_settings->@* ];
+    [
+        map { +{ %defaults, $_->%* } } $self->data_field_settings->@*,
+    ];
 }
 
 sub _build_pdf_report_writer ( $self, @ ) {

--- a/t/lib/TestForWebApp/Reports.pm
+++ b/t/lib/TestForWebApp/Reports.pm
@@ -1,0 +1,76 @@
+package TestForWebApp::Reports;
+
+use FOEGCL::Membership::Test::Class::Moose;
+
+use FOEGCL::Membership::Util::Password;
+use HTTP::Status qw(HTTP_OK);
+use Mojo::DOM ();
+use Test::Mojo;
+
+with 'FOEGCL::Membership::Role::UsesWebAppDatabase';
+
+sub test_reports ( $self, @ ) {
+    my $t = $self->_start_app_and_login;
+
+    my %report = (
+
+        # route name => anchor text
+        'contributing_friends_report' => 'Contributing Friends',
+        'current_membership_report'   => 'Current Membership',
+    );
+
+    my $dashboard = _url_for( $t, 'dashboard' );
+    foreach my $route ( keys %report ) {
+
+        $t->get_ok($dashboard)->status_is(HTTP_OK);
+
+        my $url = _url_for( $t, $route );
+        $t->text_is(
+            "li > a[href=$url]" => $report{$route},
+            "$report{$route} is listed as a link to $url"
+        );
+
+        $t->get_ok($url)->status_is(HTTP_OK)
+            ->header_is( 'Content-Type' => 'application/pdf' )
+            ->header_like(
+            'Content-Disposition' => qr/^attachment; filename="[^"]*"$/ );
+    }
+}
+
+sub _start_app_and_login ( $self, @ ) {
+
+    # Create a user to login as
+    $self->_schema->resultset('AppUser')->create(
+        {
+            username => 'testuser',
+            password_hash =>
+                FOEGCL::Membership::Util::Password->new->hash_password(
+                'the_password'),
+            first_name => 'Test',
+            last_name  => 'User',
+        }
+    );
+
+    # Start the app and login
+    my $t = Test::Mojo->new('FOEGCL::Membership');
+
+    $t->get_ok( _url_for( $t, 'login_form' ) )->status_is(HTTP_OK)
+        ->element_exists('form input[name="username"]')
+        ->element_exists('form input[name="password"]')
+        ->element_exists('form input[type="submit"]');
+
+    $t->ua->max_redirects(1);
+    $t->post_ok(
+        '/' => form => { username => 'testuser', password => 'the_password' }
+    )->status_is(HTTP_OK)->text_is( 'div.alert-success' => 'Welcome!' );
+
+    return $t;
+}
+
+sub _url_for ( $t, $route_name ) {
+    $t->app->routes->lookup($route_name)->render;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/website/templates/dashboard/dashboard.html.ep
+++ b/website/templates/dashboard/dashboard.html.ep
@@ -2,8 +2,26 @@
 
 <div class="container">
     <div class="row">
-        <div class="col">
-            Here we are.
-        </div>
+        <section class="col-6">
+            <h3>Main</h3>
+            <ul>
+                <li>Search</li>
+                <li>New person</li>
+                <li>New affiliation/membership</li>
+            </ul>
+        </section>
+        <section class="col-6">
+            <h3>Reports</h3>
+            <ul>
+                <li><%= link_to 'Current Membership' => 'current_membership_report' %></li>
+                <li><%= link_to 'Contributing Friends' => 'contributing_friends_report' %></li>
+                <li>Blast Email List</li>
+                <li>Primary Membership Mailing List</li>
+                <li>Reminder Membership Mailing List</li>
+                <li>Year End Donation Appeal Mailing List</li>
+                <li>GOTV Callers List</li>
+                <li>GOTV Registered Voters Calling List</li>
+            </ul>
+        </section>
     </div>
 </div>


### PR DESCRIPTION
This PR wires up the Contributing Friends and Current Membership reports and makes them accessible as links on the dashboard.