### PR TITLE
Fix Legacy DB connection

### DIFF
--- a/lib/FOEGCL/Membership/Role/UsesLegacyDatabase.pm
+++ b/lib/FOEGCL/Membership/Role/UsesLegacyDatabase.pm
@@ -27,7 +27,7 @@ sub _build_legacy_schema ( $self, @ ) {
         if $OSNAME !~ m/MSWin32/;
 
     return FOEGCL::Membership::Schema::Legacy->connect(
-        FOEGCL::Membership::Storage::LegacyDatabaseConnection->instance
+        FOEGCL::Membership::Storage::LegacyDatabaseConnection->new->db_config
             ->connect_info->@* );
 }
 

--- a/lib/FOEGCL/Membership/Storage/LegacyDatabaseConnection.pm
+++ b/lib/FOEGCL/Membership/Storage/LegacyDatabaseConnection.pm
@@ -5,14 +5,18 @@ package FOEGCL::Membership::Storage::LegacyDatabaseConnection;
 use FOEGCL::Membership::Moose;
 
 use Const::Fast 'const';
+use FOEGCL::Membership::Storage::LegacyDatabaseConnectionConfig ();
 use FOEGCL::Membership::Types
     qw( HashRef Maybe NonEmptySimpleStr PortNumber );
 use Module::Runtime 'require_module';
 
 has db_config => (
-    is       => 'ro',
-    does     => 'ConfiguresDatabaseConnection',
-    required => 1,
+    is      => 'ro',
+    does    => 'FOEGCL::Membership::Role::ConfiguresDatabaseConnection',
+    lazy    => 1,
+    default => sub {
+        FOEGCL::Membership::Storage::LegacyDatabaseConnectionConfig->new;
+    },
 );
 
 has schema => (


### PR DESCRIPTION
Changes to the DB connection and configuration classes were not tested on the Legacy side (as no ETL code was under consideration). This PR fixes the connection to the legacy DB.