### PR TITLE
Fix and link up the blast email list

### DIFF
--- a/lib/FOEGCL/Membership.pm
+++ b/lib/FOEGCL/Membership.pm
@@ -35,6 +35,8 @@ sub startup {
 
 sub _set_up_report_routes($logged_in) {
     my $report = $logged_in->under('/report');
+    $report->get('blast-email-list')->to('report#blast_email_list')
+        ->name('blast_email_list');
     $report->get('contributing-friends')->to('report#contributing_friends')
         ->name('contributing_friends_report');
     $report->get('current-membership')->to('report#current_membership')

--- a/lib/FOEGCL/Membership/Controller/Report.pm
+++ b/lib/FOEGCL/Membership/Controller/Report.pm
@@ -7,8 +7,17 @@ use FOEGCL::Membership::Report::ContributingFriends ();
 use FOEGCL::Membership::Report::Membership          ();
 use Mojo::Asset::Memory                             ();
 
-sub current_membership ($self) {
-    my $report = FOEGCL::Membership::Report::Membership->new;
+with 'FOEGCL::Membership::Role::UsesWebAppDatabase';
+
+sub blast_email_list ($self) {
+    my @emails = map { $_->{email_address} }
+        $self->_schema->resultset('ReportBlastEmailList')->hri->all;
+
+    $self->render( text => join ', ', @emails );
+}
+
+sub contributing_friends ($self) {
+    my $report = FOEGCL::Membership::Report::ContributingFriends->new;
 
     $self->_render_pdf_asset(
         $report->basename,
@@ -16,8 +25,8 @@ sub current_membership ($self) {
     );
 }
 
-sub contributing_friends ($self) {
-    my $report = FOEGCL::Membership::Report::ContributingFriends->new;
+sub current_membership ($self) {
+    my $report = FOEGCL::Membership::Report::Membership->new;
 
     $self->_render_pdf_asset(
         $report->basename,

--- a/website/templates/dashboard/dashboard.html.ep
+++ b/website/templates/dashboard/dashboard.html.ep
@@ -15,7 +15,7 @@
             <ul>
                 <li><%= link_to 'Current Membership' => 'current_membership_report' %></li>
                 <li><%= link_to 'Contributing Friends' => 'contributing_friends_report' %></li>
-                <li>Blast Email List</li>
+                <li><%= link_to 'Blast Email List' => 'blast_email_list' %></li>
                 <li>Primary Membership Mailing List</li>
                 <li>Reminder Membership Mailing List</li>
                 <li>Year End Donation Appeal Mailing List</li>


### PR DESCRIPTION
The blast email list report did not match up with the same report from the legacy database. The cause was that the legacy database was:

* Counting zero-valued donations as donations, and
* Looking at 2016 and 2017 for whether a donation was made in 2017 or 2018 :(.

Both issues are now resolved in the legacy database. No changes were necessary in the webapp report.

This PR also wires-up the report for access from the dashboard.