### PR TITLE
Test the Blast Email List in the WebApp

### DIFF
--- a/lib/FOEGCL/Membership/Controller/Report.pm
+++ b/lib/FOEGCL/Membership/Controller/Report.pm
@@ -6,6 +6,7 @@ extends 'Mojolicious::Controller';
 use FOEGCL::Membership::Report::ContributingFriends ();
 use FOEGCL::Membership::Report::Membership          ();
 use Mojo::Asset::Memory                             ();
+use POSIX 'strftime';
 
 with 'FOEGCL::Membership::Role::UsesWebAppDatabase';
 
@@ -13,14 +14,23 @@ sub blast_email_list ($self) {
     my @emails = map { $_->{email_address} }
         $self->_schema->resultset('ReportBlastEmailList')->hri->all;
 
-    $self->render( text => join ', ', @emails );
+    $self->_render_file_from_asset(
+        sprintf(
+            '%s %s',
+            'Blast Email List',
+            DateTime->now->strftime('%Y%m%d %H%M%S.txt')
+        ),
+        'text/plain; charset=utf-8',
+        Mojo::Asset::Memory->new->add_chunk( join ', ', @emails ),
+    );
 }
 
 sub contributing_friends ($self) {
     my $report = FOEGCL::Membership::Report::ContributingFriends->new;
 
-    $self->_render_pdf_asset(
+    $self->_render_file_from_asset(
         $report->basename,
+        'application/pdf',
         Mojo::Asset::Memory->new->add_chunk( $report->stringify ),
     );
 }
@@ -28,15 +38,16 @@ sub contributing_friends ($self) {
 sub current_membership ($self) {
     my $report = FOEGCL::Membership::Report::Membership->new;
 
-    $self->_render_pdf_asset(
+    $self->_render_file_from_asset(
         $report->basename,
+        'application/pdf',
         Mojo::Asset::Memory->new->add_chunk( $report->stringify ),
     );
 }
 
-sub _render_pdf_asset ( $self, $basename, $asset ) {
+sub _render_file_from_asset ( $self, $basename, $content_type, $asset ) {
     my $clean_basename = $basename =~ s/"//gr;
-    $self->res->headers->content_type('application/pdf');
+    $self->res->headers->content_type($content_type);
     $self->res->headers->content_disposition(
         qq{attachment; filename="$clean_basename"});
     $self->reply->asset($asset);

--- a/t/lib/TestForWebApp/Reports.pm
+++ b/t/lib/TestForWebApp/Reports.pm
@@ -7,16 +7,42 @@ use TestHelper::WebApp qw( create_webapp_user login t url_for );
 
 with 'FOEGCL::Membership::Role::UsesWebAppDatabase';
 
+sub _is_pdf_report ($t) {
+    $t->status_is(HTTP_OK)->header_is( 'Content-Type' => 'application/pdf' )
+        ->header_like(
+        'Content-Disposition' => qr/^attachment; filename="[^"]*"$/ );
+}
+
+sub _is_text_report ($t) {
+    $t->status_is(HTTP_OK)
+        ->header_is( 'Content-Type' => 'text/plain; charset=utf-8' )
+        ->header_like(
+        'Content-Disposition' => qr/^attachment; filename="[^"]*"$/ );
+}
+
+my %verify = (
+    pdf  => \&_is_pdf_report,
+    text => \&_is_text_report,
+);
+
 sub test_reports ( $self, @ ) {
     my ( $username, $password ) = create_webapp_user( $self->_schema );
     my $t = t();
     login( $t, $username, $password );
 
     my %report = (
-
-        # route name => anchor text
-        'contributing_friends_report' => 'Contributing Friends',
-        'current_membership_report'   => 'Current Membership',
+        'blast_email_list' => {
+            anchor_text => 'Blast Email List',
+            type        => 'text',
+        },
+        'contributing_friends_report' => {
+            anchor_text => 'Contributing Friends',
+            type        => 'pdf',
+        },
+        'current_membership_report' => {
+            anchor_text => 'Current Membership',
+            type        => 'pdf',
+        },
     );
 
     my $dashboard = url_for( $t, 'dashboard' );
@@ -25,14 +51,12 @@ sub test_reports ( $self, @ ) {
 
         my $url = url_for( $t, $route );
         $t->text_is(
-            "li > a[href=$url]" => $report{$route},
-            "$report{$route} is listed as a link to $url"
+            "li > a[href=$url]" => $report{$route}{anchor_text},
+            "$report{$route}{anchor_text} is listed as a link to $url"
         );
 
-        $t->get_ok($url)->status_is(HTTP_OK)
-            ->header_is( 'Content-Type' => 'application/pdf' )
-            ->header_like(
-            'Content-Disposition' => qr/^attachment; filename="[^"]*"$/ );
+        $t->get_ok($url);
+        $verify{ $report{$route}{type} }->($t);
     }
 }
 


### PR DESCRIPTION
I forgot to add a test to check that the Blast Email List works in the webapp. This PR adds that test. It also converts the report type from just a list of text on an HTML page to a proper text file with a suggested name as a file download.